### PR TITLE
Feature/rsp 1333 record individual payments

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,7 @@
 		}]
 	],
 	"plugins": [
-		"add-module-exports"
+		"add-module-exports",
+		"transform-object-rest-spread"
 	]
 }

--- a/mock-data/fake-group-payments.json
+++ b/mock-data/fake-group-payments.json
@@ -1,37 +1,32 @@
 [{
     "ID": "15xk9i0xujgg",
-    "PaymentDetail": {
-      "PaymentRef": "REF12345",
-      "AuthCode": "1234TBD",
-      "PaymentAmount": 80,
-      "PaymentDate": 1519300376667
+    "Payments": {
+      "FPN": {
+        "PaymentRef": "REF12345",
+        "AuthCode": "1234TBD",
+        "PaymentAmount": "80",
+        "PaymentDate": 1519300376667,
+        "PaymentStatus": "UNPAID"
+      },
+      "IM": {
+        "PaymentRef": "RJF12345",
+        "AuthCode": "1234TBG",
+        "PaymentAmount": "80",
+        "PaymentDate": 1519300376667,
+        "PaymentStatus": "PAID"
+      }
     }
   },
   {
     "ID": "15xef9lt3bhc",
-    "PaymentDetail": {
-      "PaymentRef": "RJF12345",
-      "AuthCode": "1234CCC",
-      "PaymentAmount": 200,
-      "PaymentDate": 1519300376667
-    }
-  },
-  {
-    "ID": "15xef9lt3bhs",
-    "PaymentDetail": {
-      "PaymentRef": "RGF12345",
-      "AuthCode": "1234AAA",
-      "PaymentAmount": 800,
-      "PaymentDate": 1519300376667
-    }
-  },
-  {
-    "ID": "15xef9lt3bbb",
-    "PaymentDetail": {
-      "PaymentRef": "RHF12345",
-      "AuthCode": "1234BBB",
-      "PaymentAmount": 400,
-      "PaymentDate": 1519300376667
+    "Payments": {
+      "FPN": {
+        "PaymentRef": "RGF12345",
+        "AuthCode": "1234AAA",
+        "PaymentAmount": "80",
+        "PaymentDate": 1519300376667,
+        "PaymentStatus": "UNPAID"
+      }
     }
   }
 ]

--- a/mock-data/fake-group-payments.json
+++ b/mock-data/fake-group-payments.json
@@ -4,7 +4,7 @@
       "FPN": {
         "PaymentRef": "REF12345",
         "AuthCode": "1234TBD",
-        "PaymentAmount": "800",
+        "PaymentAmount": 800,
         "PaymentDate": 1519300376667,
         "PaymentStatus": "UNPAID"
       },
@@ -23,7 +23,7 @@
       "FPN": {
         "PaymentRef": "RGF12345",
         "AuthCode": "1234AAA",
-        "PaymentAmount": "80",
+        "PaymentAmount": 80,
         "PaymentDate": 1519300376667,
         "PaymentStatus": "UNPAID"
       }

--- a/mock-data/fake-group-payments.json
+++ b/mock-data/fake-group-payments.json
@@ -11,7 +11,7 @@
       "IM": {
         "PaymentRef": "RJF12345",
         "AuthCode": "1234TBG",
-        "PaymentAmount": "80",
+        "PaymentAmount": 80,
         "PaymentDate": 1519300376667,
         "PaymentStatus": "PAID"
       }

--- a/mock-data/fake-group-payments.json
+++ b/mock-data/fake-group-payments.json
@@ -4,7 +4,7 @@
       "FPN": {
         "PaymentRef": "REF12345",
         "AuthCode": "1234TBD",
-        "PaymentAmount": "80",
+        "PaymentAmount": "800",
         "PaymentDate": 1519300376667,
         "PaymentStatus": "UNPAID"
       },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-register": "^6.26.0",
     "copyfiles": "^1.2.0",

--- a/src/services/groupPayments.js
+++ b/src/services/groupPayments.js
@@ -118,7 +118,6 @@ export default class GroupPayments {
 		};
 
 		this.db.get(params, (err, data) => {
-
 			if (err) {
 				error = createResponse({
 					body: { err },
@@ -126,6 +125,7 @@ export default class GroupPayments {
 				});
 				callback(error);
 			} else {
+				if (isEmptyObject(data)) callback(null, createResponse({ statusCode: 404 }));
 				const payment = data.Item;
 				response = createResponse({ body: payment });
 				callback(null, response);

--- a/src/services/groupPayments.js
+++ b/src/services/groupPayments.js
@@ -17,9 +17,7 @@ export default class GroupPayments {
 		if (body.PaymentCode === '') {
 			const err = 'Invalid Id';
 			const errorToReturn = createResponse({
-				body: {
-					err,
-				},
+				body: { err },
 				statusCode: 400,
 			});
 			callback(null, errorToReturn);
@@ -70,12 +68,12 @@ export default class GroupPayments {
 						});
 				} else {
 					// Update existing item
-					const item = data.Item[body.PenaltyType];
+					const paymentItem = data.Item.Payments[body.PenaltyType];
 					// Return 400 bad request if payment already exists
-					if (typeof item !== 'undefined' && !isEmptyObject(item)) {
+					if (typeof paymentItem !== 'undefined' && !isEmptyObject(paymentItem)) {
 						callback(null, createResponse({
 							statusCode: 400,
-							body: new Error(`Payment for ${body.PenaltyType} already exists`),
+							body: `Payment for ${body.PenaltyType} already exists in ${body.PaymentCode} payment group`,
 						}));
 						return;
 					}

--- a/src/services/groupPayments.js
+++ b/src/services/groupPayments.js
@@ -74,7 +74,6 @@ export default class GroupPayments {
 						});
 				} else {
 					// Update existing item if it exists
-					
 				}
 			})
 			.catch((err) => {

--- a/src/services/groupPayments.js
+++ b/src/services/groupPayments.js
@@ -49,7 +49,7 @@ export default class GroupPayments {
 					this.db.put(putParams).promise()
 						.then(() => {
 							response = createResponse({
-								body: { payment: putParams.Item },
+								body: putParams.Item,
 								statusCode: 201,
 							});
 							GroupPayments.updatePenaltyGroupPaymentRecord(
@@ -121,19 +121,13 @@ export default class GroupPayments {
 
 			if (err) {
 				error = createResponse({
-					body: {
-						err,
-					},
+					body: { err },
 					statusCode: 500,
 				});
 				callback(error);
 			} else {
 				const payment = data.Item;
-				response = createResponse({
-					body: {
-						payment,
-					},
-				});
+				response = createResponse({ body: payment });
 				callback(null, response);
 			}
 		});

--- a/src/test/groupPayments.serviceInt.js
+++ b/src/test/groupPayments.serviceInt.js
@@ -101,8 +101,7 @@ describe('penaltyGroups', () => {
 					.expect('Content-Type', 'application/json')
 					.end((err, res) => {
 						if (err) throw err;
-						expect(res.body.ID).toBe('12212');
-						expect(res.body.Payments.FPN)
+						expect(res.body)
 							.toEqual({
 								...fakePenaltyGroupPaymentRecordPayload.PaymentDetail,
 								PaymentStatus: 'PAID',

--- a/src/test/groupPayments.serviceInt.js
+++ b/src/test/groupPayments.serviceInt.js
@@ -43,6 +43,20 @@ describe('penaltyGroups', () => {
 					});
 			});
 		});
+		context('an individual penalty group payment record that doesn\'t exist', () => {
+			it('should return the payment details of the group', (done) => {
+				request
+					.get('/doesnotexist')
+					.set('Content-Type', 'application/json')
+					.set('Authorization', 'allow')
+					.expect(404)
+					.expect('Content-Type', 'application/json')
+					.end((err) => {
+						if (err) throw err;
+						done();
+					});
+			});
+		});
 	});
 
 	context('POST', () => {

--- a/src/test/groupPayments.serviceInt.js
+++ b/src/test/groupPayments.serviceInt.js
@@ -31,12 +31,12 @@ describe('penaltyGroups', () => {
 						expect(res.body.ID).toEqual(groupId);
 						expect(res.body.Payments.FPN.PaymentRef).toBe('REF12345');
 						expect(res.body.Payments.FPN.AuthCode).toBe('1234TBD');
-						expect(res.body.Payments.FPN.PaymentAmount).toBe('800');
+						expect(res.body.Payments.FPN.PaymentAmount).toBe(800);
 						expect(res.body.Payments.FPN.PaymentDate).toBe(1519300376667);
 						expect(res.body.Payments.FPN.PaymentStatus).toBe('UNPAID');
 						expect(res.body.Payments.IM.PaymentRef).toBe('RJF12345');
 						expect(res.body.Payments.IM.AuthCode).toBe('1234TBG');
-						expect(res.body.Payments.IM.PaymentAmount).toBe('80');
+						expect(res.body.Payments.IM.PaymentAmount).toBe(80);
 						expect(res.body.Payments.IM.PaymentDate).toBe(1519300376667);
 						expect(res.body.Payments.IM.PaymentStatus).toBe('PAID');
 						done();

--- a/src/test/groupPayments.serviceInt.js
+++ b/src/test/groupPayments.serviceInt.js
@@ -146,7 +146,35 @@ describe('penaltyGroups', () => {
 					.expect(400)
 					.end((err, res) => {
 						if (err) throw err;
-						expect(res.body).toBe('Payment for IM already exists in 12212 payment group');
+						expect(res.body.err).toBe('Payment for IM already exists in 12212 payment group');
+						done();
+					});
+			});
+		});
+
+		context('a new penalty group payment record with an invalid penalty type', () => {
+			it('should return created penalty group payment record with generated ID', (done) => {
+				const fakePenaltyGroupPaymentRecordPayload = {
+					PaymentCode: '123432jkew',
+					PenaltyType: 'INVALID',
+					PaymentDetail: {
+						PaymentMethod: 'CARD',
+						PaymentRef: 'receipt_reference',
+						AuthCode: 'auth_code',
+						PaymentAmount: 120,
+						PaymentDate: 1533200397,
+					},
+				};
+				request
+					.post('/')
+					.set('Content-Type', 'application/json')
+					.set('Authorization', 'allow')
+					.send(fakePenaltyGroupPaymentRecordPayload)
+					.expect(400)
+					.expect('Content-Type', 'application/json')
+					.end((err, res) => {
+						if (err) throw err;
+						expect(res.body.err).toBe('Invalid penalty type INVALID, must be either FPN, IM or CDN');
 						done();
 					});
 			});

--- a/src/test/groupPayments.serviceInt.js
+++ b/src/test/groupPayments.serviceInt.js
@@ -57,7 +57,6 @@ describe('penaltyGroups', () => {
 						AuthCode: 'auth_code',
 						PaymentAmount: 120,
 						PaymentDate: 1533200397,
-						PaymentStatus: 'PAID',
 					},
 				};
 				request
@@ -71,7 +70,70 @@ describe('penaltyGroups', () => {
 						if (err) throw err;
 						expect(res.body.ID).toBe('12212');
 						expect(res.body.Payments.FPN)
-							.toEqual(fakePenaltyGroupPaymentRecordPayload.PaymentDetail);
+							.toEqual({
+								...fakePenaltyGroupPaymentRecordPayload.PaymentDetail,
+								PaymentStatus: 'PAID',
+							});
+						done();
+					});
+			});
+		});
+
+		context('a new IM payment for an existing penalty group payment record', () => {
+			it('should return created penalty group payment record with generated ID', (done) => {
+				const fakePenaltyGroupPaymentRecordPayload = {
+					PaymentCode: '12212',
+					PenaltyType: 'IM',
+					PaymentDetail: {
+						PaymentMethod: 'CARD',
+						PaymentRef: 'receipt_reference',
+						AuthCode: 'auth_code',
+						PaymentAmount: 80,
+						PaymentDate: 1533200397,
+					},
+				};
+				request
+					.post('/')
+					.set('Content-Type', 'application/json')
+					.set('Authorization', 'allow')
+					.send(fakePenaltyGroupPaymentRecordPayload)
+					.expect(200)
+					.expect('Content-Type', 'application/json')
+					.end((err, res) => {
+						if (err) throw err;
+						expect(res.body.ID).toBe('12212');
+						expect(res.body.Payments.FPN)
+							.toEqual({
+								...fakePenaltyGroupPaymentRecordPayload.PaymentDetail,
+								PaymentStatus: 'PAID',
+							});
+						done();
+					});
+			});
+		});
+
+		context('an IM payment for an existing penalty group payment record with an existing IM payment', () => {
+			it('should return created penalty group payment record with generated ID', (done) => {
+				const fakePenaltyGroupPaymentRecordPayload = {
+					PaymentCode: '12212',
+					PenaltyType: 'IM',
+					PaymentDetail: {
+						PaymentMethod: 'CARD',
+						PaymentRef: 'receipt_reference',
+						AuthCode: 'auth_code',
+						PaymentAmount: 80,
+						PaymentDate: 1533200397,
+					},
+				};
+				request
+					.post('/')
+					.set('Content-Type', 'application/json')
+					.set('Authorization', 'allow')
+					.send(fakePenaltyGroupPaymentRecordPayload)
+					.expect(400)
+					.end((err, res) => {
+						if (err) throw err;
+						expect(res.body).toBe('Payment for IM already exists in 12212 payment group');
 						done();
 					});
 			});

--- a/src/test/groupPayments.serviceInt.js
+++ b/src/test/groupPayments.serviceInt.js
@@ -6,7 +6,7 @@ import AWS from 'aws-sdk';
 
 const url = 'http://localhost:3000/groupPayments';
 const request = supertest(url);
-const groupId = '15xef9lt3bbb';
+const groupId = '15xk9i0xujgg';
 
 describe('penaltyGroups', () => {
 
@@ -28,11 +28,17 @@ describe('penaltyGroups', () => {
 					.expect('Content-Type', 'application/json')
 					.end((err, res) => {
 						if (err) throw err;
-						expect(res.body.payment.ID).toEqual(groupId);
-						expect(res.body.payment.PaymentDetail.PaymentRef).toBe('RHF12345');
-						expect(res.body.payment.PaymentDetail.AuthCode).toBe('1234BBB');
-						expect(res.body.payment.PaymentDetail.PaymentAmount).toBe(400);
-						expect(res.body.payment.PaymentDetail.PaymentDate).toBe(1519300376667);
+						expect(res.body.ID).toEqual(groupId);
+						expect(res.body.Payments.FPN.PaymentRef).toBe('REF12345');
+						expect(res.body.Payments.FPN.AuthCode).toBe('1234TBD');
+						expect(res.body.Payments.FPN.PaymentAmount).toBe('800');
+						expect(res.body.Payments.FPN.PaymentDate).toBe(1519300376667);
+						expect(res.body.Payments.FPN.PaymentStatus).toBe('UNPAID');
+						expect(res.body.Payments.IM.PaymentRef).toBe('RJF12345');
+						expect(res.body.Payments.IM.AuthCode).toBe('1234TBG');
+						expect(res.body.Payments.IM.PaymentAmount).toBe('80');
+						expect(res.body.Payments.IM.PaymentDate).toBe(1519300376667);
+						expect(res.body.Payments.IM.PaymentStatus).toBe('PAID');
 						done();
 					});
 			});
@@ -51,6 +57,7 @@ describe('penaltyGroups', () => {
 						AuthCode: 'auth_code',
 						PaymentAmount: 120,
 						PaymentDate: 1533200397,
+						PaymentStatus: 'PAID',
 					},
 				};
 				request
@@ -62,8 +69,8 @@ describe('penaltyGroups', () => {
 					.expect('Content-Type', 'application/json')
 					.end((err, res) => {
 						if (err) throw err;
-						expect(res.body.payment.ID).toBe('12212');
-						expect(res.body.payment.PaymentDetail)
+						expect(res.body.ID).toBe('12212');
+						expect(res.body.Payments.FPN)
 							.toEqual(fakePenaltyGroupPaymentRecordPayload.PaymentDetail);
 						done();
 					});

--- a/src/utils/isEmptyObject.js
+++ b/src/utils/isEmptyObject.js
@@ -1,0 +1,3 @@
+export default (obj) => {
+	return Object.keys(obj).length === 0 && obj.constructor === Object;
+};


### PR DESCRIPTION
- Updates schema for paymentGroup table item
- When POSTing a new payment, the service will now check to see whether there is an entry against that penalty group ID and handle things in the following way:
  - POSTing a new payment for a payment group that doesn't already exist creates a new payment group in the table with a key in the `Payments` object for that penalty type, returns the payment details along with a payment status.
  - POSTing a new payment for an existing payment group updates the payment group with a new payment under the key of the new payment type.
   - POSTing a new payment for an existing payment group with an existing payment for the posted penalty type will return a 400 bad request error.
- Returns agreed schema when getting a payment group.