### PR TITLE
RSP-1664: Reverse group payment

### DIFF
--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -392,6 +392,7 @@ resources:
                 - dynamodb:GetItem
                 - dynamodb:PutItem
                 - dynamodb:BatchGetItem 
+                - dynamodb:BatchWriteItem
                 - dynamodb:UpdateItem
                 - dynamodb:DeleteItem
               Resource: arn:aws:dynamodb:*:*:table/paymentsTable

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -163,6 +163,41 @@ functions:
                   description: "500 server error"
                 responseModels:
                   application/json: "ErrorResponse"
+  deletePenaltyGroupPaymentRecord:
+    handler: handler.deletePenaltyGroupPaymentRecord
+    memorySize: 128
+    events:
+      -
+        http:
+          path: groupPayments/{id}/{penaltyType}
+          method: delete
+          authorizer: aws_iam
+          cors: true
+          documentation:
+            summary: "Delete payment details for a penalty group"
+            description: "Updates a penalty group and child documents to reflect payment deletion"
+            pathParmas:
+              - name: "id"
+                description: "The penalty-group-payment id"
+                schema:
+                  type: "string"
+                  pattern: "^[0-9]+$"
+              - name: "penaltyType"
+                description: "The penalty type of the payments to delete within a group"
+                schema:
+                  type: "string"
+                  pattern: "^[0-9]+$"
+          methodResponses:
+            - statusCode: 200
+              responseBody:
+                description: "Details of the updated payment group"
+              responseModels:
+                application/json: "PaymentsResponse"
+            - statusCode: 501
+              responseBody:
+                descriptions: "501 not implemented"
+              responseModels:
+                application/json: "ErrorResponse"
   create:
     handler: handler.create
     memorySize: 128

--- a/src/functions/createPenaltyGroupPaymentRecord.js
+++ b/src/functions/createPenaltyGroupPaymentRecord.js
@@ -5,6 +5,7 @@ import createResponse from '../utils/createResponse';
 const payments = new GroupPayments(
 	doc,
 	process.env.DYNAMODB_GROUP_PAYMENTS_TABLE,
+	process.env.PENALTYGROUP_UPDATE_ARN,
 	process.env.PENALTY_DOCS_UPDATE_ARN,
 	process.env.DOCUMENTUPDATE_ARN,
 );

--- a/src/functions/createPenaltyGroupPaymentRecord.js
+++ b/src/functions/createPenaltyGroupPaymentRecord.js
@@ -5,7 +5,7 @@ import createResponse from '../utils/createResponse';
 const payments = new GroupPayments(
 	doc,
 	process.env.DYNAMODB_GROUP_PAYMENTS_TABLE,
-	process.env.PENALTYGROUP_UPDATE_ARN,
+	process.env.PENALTY_DOCS_UPDATE_ARN,
 	process.env.DOCUMENTUPDATE_ARN,
 );
 

--- a/src/functions/deletePenaltyGroupPaymentRecord.js
+++ b/src/functions/deletePenaltyGroupPaymentRecord.js
@@ -5,6 +5,7 @@ const groupPayments = new GroupPayments(
 	doc,
 	process.env.DYNAMODB_GROUP_PAYMENTS_TABLE,
 	process.env.PENALTYGROUP_UPDATE_ARN,
+	process.env.PENALTY_DOCS_UPDATE_ARN,
 	process.env.DOCUMENTUPDATE_ARN,
 );
 

--- a/src/functions/deletePenaltyGroupPaymentRecord.js
+++ b/src/functions/deletePenaltyGroupPaymentRecord.js
@@ -10,7 +10,6 @@ const groupPayments = new GroupPayments(
 );
 
 export default (event, context, callback) => {
-	const { id, type } = event.pathParameters;
-	groupPayments.deletePenaltyGroupPaymentRecord(id, type, callback);
-
+	const { id, penaltyType } = event.pathParameters;
+	groupPayments.deletePenaltyGroupPaymentRecord(id, penaltyType, callback);
 };

--- a/src/functions/deletePenaltyGroupPaymentRecord.js
+++ b/src/functions/deletePenaltyGroupPaymentRecord.js
@@ -1,5 +1,6 @@
 import { doc } from 'serverless-dynamodb-client';
 import GroupPayments from '../services/groupPayments';
+import Payments from '../services/payments';
 
 const groupPayments = new GroupPayments(
 	doc,
@@ -9,7 +10,33 @@ const groupPayments = new GroupPayments(
 	process.env.DOCUMENTUPDATE_ARN,
 );
 
+const payments = new Payments(
+	doc,
+	process.env.DYNAMODB_PAYMENTS_TABLE,
+	process.env.DECRYPT_ARN,
+	process.env.DOCUMENTUPDATE_ARN,
+	process.env.DOCUMENTDELETE_ARN,
+);
+
+function deletePayments(penaltyIds) {
+	penaltyIds.forEach((penaltyId) => {
+		payments.deletePaymentOnly(penaltyId, (paymentDeleteErr) => {
+			console.log('Encountered error when deleting payment for group payment.');
+			console.log(paymentDeleteErr);
+		});
+	});
+}
+
 export default (event, context, callback) => {
 	const { id, penaltyType } = event.pathParameters;
-	groupPayments.deletePenaltyGroupPaymentRecord(id, penaltyType, callback);
+	groupPayments.deletePenaltyGroupPaymentRecord(
+		id,
+		penaltyType,
+		((err, httpResponse, penaltyIds) => {
+			if (!err && penaltyIds !== undefined) {
+				deletePayments(penaltyIds);
+			}
+			callback(httpResponse);
+		}),
+	);
 };

--- a/src/functions/getPenaltyGroupPaymentRecord.js
+++ b/src/functions/getPenaltyGroupPaymentRecord.js
@@ -7,6 +7,7 @@ const payments = new GroupPayments(
 	doc,
 	process.env.DYNAMODB_GROUP_PAYMENTS_TABLE,
 	process.env.PENALTYGROUP_UPDATE_ARN,
+	process.env.PENALTY_DOCS_UPDATE_ARN,
 	process.env.DOCUMENTUPDATE_ARN,
 );
 

--- a/src/services/groupPayments.js
+++ b/src/services/groupPayments.js
@@ -5,10 +5,10 @@ import isEmptyObject from '../utils/isEmptyObject';
 
 const lambda = new Lambda({ region: 'eu-west-1' });
 export default class GroupPayments {
-	constructor(db, tableName, updatePenaltyGroupPaymentRecordArn, documentUpdateArn) {
+	constructor(db, tableName, updateMultiplePenaltyDocumentsArn, documentUpdateArn) {
 		this.db = db;
 		this.tableName = tableName;
-		this.updatePenaltyGroupPaymentRecordArn = updatePenaltyGroupPaymentRecordArn;
+		this.updateMultiplePenaltyDocumentsArn = updateMultiplePenaltyDocumentsArn;
 		this.documentUpdateArn = documentUpdateArn;
 	}
 
@@ -201,7 +201,7 @@ export default class GroupPayments {
 	async _applyPaymentToPenaltyGroup(id, paymentStatus, penaltyType) {
 		console.log(`Invoke updatePenaltyGroupPaymentRecord, args: ${id}, ${paymentStatus}, ${penaltyType}`);
 		return lambda.invoke({
-			FunctionName: this.updatePenaltyGroupPaymentRecordArn,
+			FunctionName: this.updateMultiplePenaltyDocumentsArn,
 			Payload: `{"body": { "id": "${id}", "paymentStatus": "${paymentStatus}", "penaltyType": "${penaltyType}" } }`,
 		}).promise();
 	}

--- a/src/services/groupPayments.js
+++ b/src/services/groupPayments.js
@@ -5,10 +5,14 @@ import isEmptyObject from '../utils/isEmptyObject';
 
 const lambda = new Lambda({ region: 'eu-west-1' });
 export default class GroupPayments {
-	constructor(db, tableName, updateMultiplePenaltyDocumentsArn, documentUpdateArn) {
+	constructor(
+		db, tableName, updatePenaltyGroupPaymentRecordArn, updateMultiplePenaltyDocumentsArn,
+		documentUpdateArn,
+	) {
 		this.db = db;
 		this.tableName = tableName;
 		this.updateMultiplePenaltyDocumentsArn = updateMultiplePenaltyDocumentsArn;
+		this.updatePenaltyGroupPaymentRecordArn = updatePenaltyGroupPaymentRecordArn;
 		this.documentUpdateArn = documentUpdateArn;
 	}
 
@@ -126,7 +130,7 @@ export default class GroupPayments {
 		};
 
 		return lambda.invoke({
-			FunctionName: this.documentUpdateArn,
+			FunctionName: this.updateMultiplePenaltyDocumentsArn,
 			Payload: JSON.stringify(payload),
 		}).promise();
 	}
@@ -201,7 +205,7 @@ export default class GroupPayments {
 	async _applyPaymentToPenaltyGroup(id, paymentStatus, penaltyType) {
 		console.log(`Invoke updatePenaltyGroupPaymentRecord, args: ${id}, ${paymentStatus}, ${penaltyType}`);
 		return lambda.invoke({
-			FunctionName: this.updateMultiplePenaltyDocumentsArn,
+			FunctionName: this.updatePenaltyGroupPaymentRecordArn,
 			Payload: `{"body": { "id": "${id}", "paymentStatus": "${paymentStatus}", "penaltyType": "${penaltyType}" } }`,
 		}).promise();
 	}

--- a/src/services/groupPayments.js
+++ b/src/services/groupPayments.js
@@ -96,6 +96,7 @@ export default class GroupPayments {
 			const penaltyGroupPaymentRecord = await this.getPenaltyGroupPaymentRecord(id);
 			const { PaymentAmount, penaltyIds } = penaltyGroupPaymentRecord.Payments[type];
 			console.log(`PaymentAmount, penaltyIds: ${PaymentAmount}, ${penaltyIds}`);
+
 			delete penaltyGroupPaymentRecord.Payments[type];
 			// Delete the entire item if there are no other payments
 			if (isEmptyObject(penaltyGroupPaymentRecord.Payments)) {
@@ -103,14 +104,14 @@ export default class GroupPayments {
 				// Need to update the document with the new payment status
 				await this._createMultipleDocumentUpdateInvocation(penaltyIds);
 				response = createResponse({ body: {} });
-				return callback(null, response);
+				return callback(null, response, penaltyIds);
 			}
 			// Otherwise just update the Payments object
 			await this.db.put(createPutUpdateParams(penaltyGroupPaymentRecord)).promise();
 			// Need to update the document(s) with the new payment status
 			await this._createMultipleDocumentUpdateInvocation(penaltyIds);
 			response = createResponse({ body: penaltyGroupPaymentRecord });
-			return callback(null, response);
+			return callback(null, response, penaltyIds);
 		} catch (err) {
 			console.log('error deleting penalty group payment record');
 			console.log(err);

--- a/src/services/payments.js
+++ b/src/services/payments.js
@@ -236,6 +236,21 @@ export default class Payments {
 
 	}
 
+	deletePaymentOnly(id, callback) {
+		const params = {
+			TableName: this.tableName,
+			Key: { ID: id },
+		};
+
+		this.db.delete(params, (err) => {
+			if (err) {
+				callback(err);
+			} else {
+				callback();
+			}
+		});
+	}
+
 	delete(id, callback) {
 		let error;
 		let response;


### PR DESCRIPTION
#### Depends on a new function created in the document service (see dvsa/rsp-documents-service#59).
#### Requires `PENALTY_DOCS_UPDATE_ARN` to be added as an environment variable/secret.

### Problem

`deletePenaltyGroupPaymentRecord` deletes the payment group and updates the penalty group to be paid. Payment status is not cascaded to children within the group when the penalty group is deleted, resulting in invalid state (where payment groups are set to `UNPAID` and payments reference a delete payment group).

### Solution

Update `deletePenaltyGroupPaymentRecord` to cascade deletion to penalties within a group. Also cascade setting payment status to `UNPAID`. The iOS application infers the payment status on the penalty group info page from the payment rather than the penalty document payment status.

Within deletePenaltyGroupPaymentRecord:
Invoke a new `PENALTY_DOCS_UPDATE_ARN` which maps to `documentService.updateMultipleUponPaymentDelete`. The benefit of this new method instead of `updateDocumentUponPaymentDelete` is that it only needs to be invoked once from the payment service (rather than N times where N is the number of documents in a group).