### PR TITLE
fix: to only run update code on default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 
   update-lambda-code:
-    #if: ${{ github.ref_name == github.event.repository.default_branch }}
+    if: ${{ github.ref_name == github.event.repository.default_branch }}
     uses: dvsa/.github/.github/workflows/update-lambda-function.yaml@v2.2
     needs: [ build-names, build, upload-s3 ]
     strategy:


### PR DESCRIPTION
## Description

- Left branch check commented out for testing, uncomment to only run updated on defaul branch

Related issue: [RSP-2085](https://dvsa.atlassian.net/browse/RSP-2085)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
