### PR TITLE
feat: Add param input validation and extra logging

### DIFF
--- a/src/functions/deletePenaltyGroupPaymentRecord.js
+++ b/src/functions/deletePenaltyGroupPaymentRecord.js
@@ -33,6 +33,7 @@ function deletePayments(penaltyIds) {
 
 export const handler = async (event) => {
 	const { id, penaltyType } = event.pathParameters;
+
 	const {
 		response,
 		penaltyIds,

--- a/src/services/groupPayments.js
+++ b/src/services/groupPayments.js
@@ -67,7 +67,7 @@ export default class GroupPayments {
 			logError('CreateGroupPaymentRecordError', {
 				paymentCode: PaymentCode,
 				penaltyType: PenaltyType,
-				error: err.message,
+				error: err.message ? err.message : err,
 			});
 			if (err.statusCode) {
 				return err;
@@ -88,6 +88,20 @@ export default class GroupPayments {
 	async deletePenaltyGroupPaymentRecord(id, type) {
 		let error;
 		let response;
+
+		if (!id || !type) {
+			logError('DeleteGroupPaymentRecordError', {
+				message: 'Error deleting penalty group payment record. Missing parameter id or type.',
+				idParam: id,
+				typeParam: type,
+			});
+			error = createResponse({
+				body: `Couldn't remove the payment of type: ${type}, for code ${id}`,
+				statusCode: 400,
+			});
+			return { response: error };
+		}
+
 		logInfo('DeleteGroupPaymentRecord', {
 			id,
 			type,
@@ -139,11 +153,12 @@ export default class GroupPayments {
 
 			return { response, penaltyIds };
 		} catch (err) {
-			logError('', {
+			logError('DeleteGroupPaymentRecordError', {
 				id,
 				type,
 				message: 'Error deleting penalty group payment record',
-				error: err.message,
+				errorMessage: err.message,
+				error: err,
 			});
 			error = createResponse({
 				body: `Couldn't remove the payment of type: ${type}, for code ${id}`,

--- a/src/services/payments.js
+++ b/src/services/payments.js
@@ -256,6 +256,7 @@ export default class Payments {
 		});
 
 		const deletedData = data.Attributes;
+
 		const paymentInfo = {
 			PenaltyStatus: deletedData.PenaltyStatus,
 			PenaltyType: deletedData.PenaltyType,


### PR DESCRIPTION
## Description

- Currently reversing a group payment from the internal portal results
  in an error being thrown even though the reverse goes through
- The error is being thrown in the payment service when the delete is
  attempted in the db due to missing penalty type
- Error was due to an api gateway change not being deployed
- Add validation to see check path parameters received by the
  payments service and return useful error if missing
- Ticket RSP-2111

Related issue: [RSP-2111](https://dvsa.atlassian.net/browse/RSP-2111)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
