### PR TITLE
feat: Add promote tag to release archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - '**'
 
 jobs:
   lint:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,8 @@ jobs:
       - name: Upload to s3
         run: >
           aws s3api copy-object
+          --tagging-directive REPLACE
+          --tagging promote=YES
           --copy-source ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}/${{ env.KEY_PATH }}/${{ matrix.lambdaName }}/${{ env.SOURCE_ZIP }}
           --key ${{ env.KEY_PATH }}/${{ matrix.lambdaName }}/release-${{ github.ref_name }}.zip
           --bucket ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}

--- a/.github/workflows/update-code.yaml
+++ b/.github/workflows/update-code.yaml
@@ -35,7 +35,7 @@ jobs:
     with:
       environment: ${{ github.event.inputs.environment }}
       lambda_function_name: rsp-nonprod-apis-payments-${{ matrix.lambdaName }}
-      bucket_key: payments/${{ matrix.lambdaName }}/${{ github.event.inputs.zip_archive }}.zip
+      bucket_key: payments/${{ matrix.lambdaName }}/${{ github.event.inputs.zip_archive }}
     permissions:
       id-token: write
     secrets:


### PR DESCRIPTION
## Description

- Add promote tag to release workflow for release archives in S3
- Remove duplicate `.zip` in upload workflow
- Only run CI on pushes to branches - not tags

Related issue: [RSP-2118](https://dvsa.atlassian.net/browse/RSP-2118)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
