### PR TITLE
fix: bumped validation package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "@dvsa/rsp-validation": "^1.9.1",
+        "@dvsa/rsp-validation": "^1.9.2",
         "aws-sdk": "^2.1251.0",
         "joi": "^17.7.0",
         "request": "^2.88.0",
@@ -2752,11 +2752,11 @@
       }
     },
     "node_modules/@dvsa/rsp-validation": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@dvsa/rsp-validation/-/rsp-validation-1.9.1.tgz",
-      "integrity": "sha512-Ro9Fus5TkYLdJhathVi2ghLc5xa00Vt2xDmXCT64Mbu+TdqDzgAPs01TT4V3lANrxIPpsof4bq9Xbjc7Lt/M9g==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@dvsa/rsp-validation/-/rsp-validation-1.9.2.tgz",
+      "integrity": "sha512-jgim4jf7kB3L+1Ds443/VLgRBIhpWrwZ5V5x2whddk6akrpFJG87zAf598tbzR0htBNOdEQ6/jdYMJV2OnfoGg==",
       "dependencies": {
-        "joi": "^17.7.0"
+        "joi": "^17.8.3"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -9839,14 +9839,14 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.0.tgz",
-      "integrity": "sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==",
+      "version": "17.8.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.8.3.tgz",
+      "integrity": "sha512-q5Fn6Tj/jR8PfrLrx4fpGH4v9qM6o+vDUfD4/3vxxyg34OmKcNqYZ1qn2mpLza96S8tL0p0rIw2gOZX+/cTg9w==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
         "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.0",
+        "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
     },
@@ -18189,11 +18189,11 @@
       "dev": true
     },
     "@dvsa/rsp-validation": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@dvsa/rsp-validation/-/rsp-validation-1.9.1.tgz",
-      "integrity": "sha512-Ro9Fus5TkYLdJhathVi2ghLc5xa00Vt2xDmXCT64Mbu+TdqDzgAPs01TT4V3lANrxIPpsof4bq9Xbjc7Lt/M9g==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@dvsa/rsp-validation/-/rsp-validation-1.9.2.tgz",
+      "integrity": "sha512-jgim4jf7kB3L+1Ds443/VLgRBIhpWrwZ5V5x2whddk6akrpFJG87zAf598tbzR0htBNOdEQ6/jdYMJV2OnfoGg==",
       "requires": {
-        "joi": "^17.7.0"
+        "joi": "^17.8.3"
       }
     },
     "@eslint/eslintrc": {
@@ -23785,14 +23785,14 @@
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "joi": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.0.tgz",
-      "integrity": "sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==",
+      "version": "17.8.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.8.3.tgz",
+      "integrity": "sha512-q5Fn6Tj/jR8PfrLrx4fpGH4v9qM6o+vDUfD4/3vxxyg34OmKcNqYZ1qn2mpLza96S8tL0p0rIw2gOZX+/cTg9w==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
         "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.0",
+        "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "@dvsa/rsp-validation": "^1.9.1",
+    "@dvsa/rsp-validation": "^1.9.2",
     "aws-sdk": "^2.1251.0",
     "joi": "^17.7.0",
     "request": "^2.88.0",


### PR DESCRIPTION
## Description

- Validation package version has been bumped to 1.9.2 to use latest version which incorporates security fixes

Related issue: [RSP-2228](https://dvsa.atlassian.net/browse/RSP-2228?atlOrigin=eyJpIjoiMzhlMTYyZmQ4M2UxNDAxYWJmMTJhMWNlMGI5ZWZjNWYiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
