### PR TITLE
ci: Release variable was set as a secret instead of var

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,6 @@ jobs:
           aws s3api copy-object
           --tagging-directive REPLACE
           --tagging promote=YES
-          --copy-source ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}/${{ secrets.S3_KEY_PATH  }}/${{ matrix.lambdaName }}/${{ env.COPY_SOURCE }}
+          --copy-source ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}/${{ vars.S3_KEY_PATH  }}/${{ matrix.lambdaName }}/${{ env.COPY_SOURCE }}
           --key ${{ vars.S3_KEY_PATH }}/${{ matrix.lambdaName }}/release-${{ needs.release-please.outputs.tag_name }}.zip
           --bucket ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}


### PR DESCRIPTION
## Description

- Fixed secret.S3_KEY_PATH to `vars` instead of `secret` inline with the other var and other CI files

Related issue: n/a

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
